### PR TITLE
changed cdn hrefs from jsdeliver to cloudfare

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
 
   <!-- Site Properties -->
   <title>Homepage - Semantic</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/semantic-ui@2.3.1/dist/semantic.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.3.1/semantic.min.css">
   <link rel="stylesheet" href="./src/style.css">
 
   <script
@@ -16,7 +16,7 @@
   integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
   crossorigin="anonymous"></script>
 
-  <script src="https://cdn.jsdelivr.net/npm/semantic-ui@2.3.1/dist/semantic.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.3.1/semantic.min.js"></script>
 
   <script
     type="text/javascript"


### PR DESCRIPTION
* **What does this PR introduce?** (Bug fix, feature, docs update, ...)
I have trouble with the jsdeliver links in various browsers i.e. could not load Semantic UI pages so page would not display properly. I have changed link and script tags to cloudfare cdn sent to me by Michael.