### PR TITLE
add display flex to ui meetup cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,10 +155,10 @@
     <div class="ui container">
       <h3 class="ui header">Some of our next meetups are going to happen on these dates:</h3>
       <h4>As a rule of thumb it's every other Thursday, but these are the ones we are sure of</h4>
-      <div class="ui cards">
+      <div class="ui cards flex-container">
         <!-- To insert a new meeting card -->
         <!-- Copy the content between this comment... -->
-        <div class="card">
+        <div class="card flex-item">
           <div class="content">
             <div class="header">Thursday 2nd August</div>
             <div class="meta">County Library, Westgate Centre, Oxford 6-8pm</div>
@@ -168,7 +168,7 @@
           </div>
         </div>
         <!-- ... and this one. the "card" div-->        
-        <div class="card">
+        <div class="card flex-item">
           <div class="content">
             <div class="header">Thursday 16th August</div>
             <div class="meta">County Library, Westgate Centre, Oxford 6-8pm</div>
@@ -177,7 +177,7 @@
             </div>
           </div>
         </div>
-        <div class="card">
+        <div class="card flex-item">
           <div class="content">
             <div class="header">Thursday 30th August</div>
             <div class="meta">County Library, Westgate Centre, Oxford 6-8pm</div>

--- a/index.html
+++ b/index.html
@@ -160,7 +160,7 @@
         <!-- Copy the content between this comment... -->
         <div class="card flex-item">
           <div class="content">
-            <div class="header">Thursday 2nd August</div>
+            <div class="header">Thursday 5nd August</div>
             <div class="meta">County Library, Westgate Centre, Oxford 6-8pm</div>
             <div class="description">
               We will be making our personal pages and just generally coding great stuff

--- a/src/style.css
+++ b/src/style.css
@@ -27,6 +27,11 @@
     background-size: cover !important;
 }
 
+.flex-container {
+    display: flex;
+    flex-flow: row;
+}
+
 .ui.vertical.stripe {
     padding: 8em 0em;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -30,6 +30,8 @@
 .flex-container {
     display: flex;
     flex-flow: row;
+    width: 100%;
+    justify-content: space-between;
 }
 
 .ui.vertical.stripe {


### PR DESCRIPTION
* **What does this PR introduce?** (Bug fix, feature, docs update, ...)

adds class of flex-container to ui cards parent div and flex-item to ui cards child divs. display flex and flex direction set as default on parent container

* **Please check if the PR fulfills these requirements:**

- [ ] Your code works.
- [ ] The commit messages makes sense.
- [ ] Reference number, if applicable.
- [ ] The introduction would make sense to someone completely unfamiliar with what is done in the PR.